### PR TITLE
Create JIRAdatalookup.sql

### DIFF
--- a/sql/jira/JIRAdatalookup
+++ b/sql/jira/JIRAdatalookup
@@ -1,0 +1,25 @@
+/* Looking up all instances where 'jira-bot' shows up in JIRA's data model*/
+SELECT CONCAT('UPDATE `', table_name, '` SET `', column_name, '` ', '`= liferay-jira-bot`', ';')
+FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA = 'jira'
+AND column_name = 'USER_KEY';
+
+/* Similarly, looking up character encoding (for fixing collation) for tables and columns*/
+/*TABLES*/
+SELECT concat('ALTER TABLE ',  table_name, ' CHARACTER SET utf8 COLLATE utf8_bin;')
+FROM information_schema.TABLES AS T, information_schema.`COLLATION_CHARACTER_SET_APPLICABILITY` AS C
+WHERE C.collation_name = T.table_collation
+AND T.table_schema = 'jira'
+AND (C.CHARACTER_SET_NAME != 'utf8' or C.COLLATION_NAME != 'utf8_bin');
+/*COLUMNS*/
+SELECT CONCAT('ALTER TABLE `', table_name, '` MODIFY `', column_name, '` ', DATA_TYPE, '(', CHARACTER_MAXIMUM_LENGTH, ') CHARACTER SET UTF8 COLLATE utf8_bin', (CASE WHEN IS_NULLABLE = 'NO' THEN ' NOT NULL' ELSE '' END), ';')
+FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA = 'jira'
+AND DATA_TYPE = 'varchar'
+AND (CHARACTER_SET_NAME != 'utf8' OR COLLATION_NAME != 'utf8_bin');
+
+SELECT CONCAT('ALTER TABLE `', table_name, '` MODIFY `', column_name, '` ', DATA_TYPE, ' CHARACTER SET UTF8 COLLATE utf8_bin', (CASE WHEN IS_NULLABLE = 'NO' THEN ' NOT NULL' ELSE '' END), ';')
+FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA = 'jira'
+AND DATA_TYPE != 'varchar'
+AND (CHARACTER_SET_NAME != 'utf8' OR COLLATION_NAME != 'utf8_bin');


### PR DESCRIPTION
A few JIRA MySQL queries used to lookup instances where a field is populated by a value. Also included is a sort of extension of the lookup, to see what collations are used where.