### PR TITLE
Create jiraFieldByFieldconfigscheme

### DIFF
--- a/sql/jira/jiraFieldsByFieldconfigscheme
+++ b/sql/jira/jiraFieldsByFieldconfigscheme
@@ -1,0 +1,6 @@
+select fl.name, fli.fieldidentifier
+FROM fieldlayoutitem fli
+JOIN fieldlayout fl
+  ON fli.fieldlayout = fl.ID
+WHERE fli.isrequired = "true"
+ORDER by fl.name asc, fli.fieldidentifier asc;


### PR DESCRIPTION
This query will pull all 'required' fields that are used by the different fieldconfigschemes, used to determine which fieldconfig schemes basically overlap. Number of FieldConfigSchemes were rated to be 4th highest impact on performance.